### PR TITLE
GRPO: compute rewards over eval set

### DIFF
--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -137,6 +137,9 @@ def setup_chat_format(
 
 def remove_hooks(model: "DeepSpeedEngine") -> None:
     """Removes the optimizer hooks from a DeepSpeed ZeRO-3 model."""
+    if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
+        # From https://github.com/huggingface/trl/pull/2776
+        return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
         optimizer_offload = model.optimizer.parameter_offload
     elif model.optimizer is not None:
@@ -164,6 +167,9 @@ def iter_params(module, recurse=False):
 
 def add_hooks(model: "DeepSpeedEngine") -> None:
     """Adds the optimizer hooks from a DeepSpeed ZeRO-3 model."""
+    if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
+        # From https://github.com/huggingface/trl/pull/2776
+        return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
         optimizer_offload = model.optimizer.parameter_offload
     elif model.optimizer is not None:

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -138,7 +138,10 @@ def setup_chat_format(
 def remove_hooks(model: "DeepSpeedEngine") -> None:
     """Removes the optimizer hooks from a DeepSpeed ZeRO-3 model."""
     if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
-        # From https://github.com/huggingface/trl/pull/2776
+        # From https://github.com/huggingface/trl/pull/2776. NOTE: I don't think the above comment
+        # (from upstream) is correct, since we hit this even after the first training step (and I
+        # think upstream does too). I think the problem is calling code is trying to unwrap the base
+        # model, not the engine. TODO: understand this properly.
         return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
         optimizer_offload = model.optimizer.parameter_offload

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -174,27 +174,3 @@ class GRPOConfig(TrainingArguments):
         default=0.04,
         metadata={"help": "KL coefficient."},
     )
-
-    # From  https://github.com/huggingface/trl/pull/2700/files
-    sync_ref_model: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to synchronize the reference model with the active model every `ref_model_sync_steps` "
-            "steps, using the `ref_model_mixup_alpha` parameter."
-        },
-    )
-    ref_model_mixup_alpha: float = field(
-        default=0.9,
-        metadata={
-            "help": "α parameter from the TR-DPO paper, which controls the mix between the current policy and the "
-            "previous reference policy during updates. The reference policy is updated according to the equation: "
-            "`π_ref = α * π_θ + (1 - α) * π_ref_prev`. To use this parameter, you must set `sync_ref_model=True`."
-        },
-    )
-    ref_model_sync_steps: int = field(
-        default=64,
-        metadata={
-            "help": "τ parameter from the TR-DPO paper, which determines how frequently the current policy is "
-            "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
-        },
-    )

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -42,7 +42,6 @@ from transformers.utils import is_peft_available, logging
 from ..data_utils import apply_chat_template, is_conversational, maybe_apply_chat_template
 from ..import_utils import is_vllm_available
 from ..models import create_reference_model, prepare_deepspeed, unwrap_model_for_generation
-from .callbacks import SyncRefModelCallback
 from .grpo_config import GRPOConfig
 from .utils import generate_model_card, get_comet_experiment_url, pad
 
@@ -353,9 +352,6 @@ class GRPOTrainer(Trainer):
                 self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
-
-        if args.sync_ref_model:
-            self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
 
         for i, reward_func in enumerate(self.reward_funcs):
             if isinstance(reward_func, PreTrainedModel):


### PR DESCRIPTION
Basically what the title says. Trainer's eval loop is built around losses/logits, so I am abusing the return and call signatures of `prediction_step` and `compute_metrics` respectively. This lets us compute+log rewards without rewriting the whole eval loop and logging mechanism. 

I also pulled in the changes from https://github.com/huggingface/trl/pull/2776, which are needed to unwrap the model for generation in the eval loop.

Most of the code diff is me pulling code out of `compute_loss` into separate methods, so they can be reused in `prediction_step`